### PR TITLE
Mel spectrogram

### DIFF
--- a/py-speechsauce/Cargo.toml
+++ b/py-speechsauce/Cargo.toml
@@ -13,8 +13,9 @@ name = "speechsauce._internal"
 
 [dependencies]
 ndarray="^0.15"
-pyo3 = {version= "0.16.5", features=["extension-module","abi3-py37"]}
-numpy = "0.16.2"
+pyo3 = {version= "0.19.0", features=["extension-module","abi3-py37"]}
+numpy = "0.19.0"
+cached = "0.44.0"
 speechsauce = { path = "../speechsauce" }
 
 

--- a/py-speechsauce/speechsauce/__init__.py
+++ b/py-speechsauce/speechsauce/__init__.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from ._internal import mfcc as internal_mfcc, _speech_config, cmvn, preemphasis
+from ._internal import mfcc as __internal_mfcc, mel_spectrogram as __internal_mel_spec, _speech_config, cmvn, preemphasis
 
 __all__ = ["mfcc", "preemphasis", "cmvn"]
 
@@ -79,4 +79,52 @@ def mfcc(
         high_frequency,
         dc_elimination,
     )
-    return internal_mfcc(signal, config)
+    return __internal_mfcc(signal, config)
+
+def mel_spectrogram(
+    signal,
+    sampling_frequency,
+    frame_length=0.020,
+    frame_stride=0.01,
+    num_filters=40,
+    fft_length=512,
+    low_frequency=0,
+    high_frequency=None,
+    dc_elimination=True,
+):
+    """Compute Mel Spectrogram features from an audio signal.
+    Args:
+        signal (array): 
+            the audio signal from which to compute features. Should be an 1 or 2d array
+        sampling_frequency (int): 
+            the sampling frequency of the signal we are working with.
+        frame_length (float): 
+            the length of each frame in seconds.
+        frame_stride (float):
+            the step between successive frames in seconds.
+        num_filters (int):
+            the number of filters in the filterbank.
+        fft_length (int):
+            number of FFT points.
+        low_frequency (float):
+            lowest band edge of mel filters.
+        high_frequency (float):
+            highest band edge of mel filters.
+        dc_elimination (bool):
+            If the first dc component should be eliminated or not.
+    Returns:
+        array:
+            array with shape (..., n_mels, time)
+    """
+    config = _get_speech_config(
+        sampling_frequency,
+        frame_length,
+        frame_stride,
+        0,
+        num_filters,
+        fft_length,
+        low_frequency,
+        high_frequency,
+        dc_elimination,
+    )
+    return __internal_mel_spec(signal, config)

--- a/py-speechsauce/src/lib.rs
+++ b/py-speechsauce/src/lib.rs
@@ -48,9 +48,9 @@ fn speechsauce(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[pyfn(m)]
     fn mfcc<'py>(
         py: Python<'py>,
-        signal: PyReadonlyArray1<f64>,
+        signal: PyReadonlyArray1<f32>,
         config: Py<PySpeechConfig>,
-    ) -> &'py PyArray2<f64> {
+    ) -> &'py PyArray2<f32> {
         let cell = config.as_ref(py);
         let obj_ref = cell.borrow();
         let speech_config = &obj_ref.0;
@@ -61,19 +61,19 @@ fn speechsauce(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     #[pyfn(m)]
     fn preemphasis<'py>(
         py: Python<'py>,
-        signal: PyReadonlyArray1<f64>,
+        signal: PyReadonlyArray1<f32>,
         shift: isize,
-        cof: f64,
-    ) -> &'py PyArray1<f64> {
+        cof: f32,
+    ) -> &'py PyArray1<f32> {
         processing::preemphasis(signal.as_array().to_owned(), shift, cof).into_pyarray(py)
     }
 
     #[pyfn(m)]
     fn cmvn<'py>(
         py: Python<'py>,
-        vec: PyReadonlyArray2<f64>,
+        vec: PyReadonlyArray2<f32>,
         variance_normalization: bool,
-    ) -> &'py PyArray2<f64> {
+    ) -> &'py PyArray2<f32> {
         processing::cmvn(vec.as_array(), variance_normalization).into_pyarray(py)
     }
 
@@ -81,13 +81,13 @@ fn speechsauce(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     fn _speech_config<'py>(
         py: Python<'py>,
         sampling_frequency: usize,
-        frame_length: f64,           // =0.020,
-        frame_stride: f64,           // =0.01,
+        frame_length: f32,           // =0.020,
+        frame_stride: f32,           // =0.01,
         num_cepstral: usize,         // =13,
         num_filters: usize,          // =40,
         fft_length: usize,           // =512,
-        low_frequency: f64,          // =0,
-        high_frequency: Option<f64>, // =None,
+        low_frequency: f32,          // =0,
+        high_frequency: Option<f32>, // =None,
         dc_elimination: bool,        //True
     ) -> Py<PySpeechConfig> {
         Py::new(
@@ -100,7 +100,7 @@ fn speechsauce(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
                 num_cepstral,
                 num_filters,
                 low_frequency,
-                high_frequency.unwrap_or(sampling_frequency as f64 / 2.0),
+                high_frequency.unwrap_or(sampling_frequency as f32 / 2.0),
                 dc_elimination,
             )),
         )

--- a/py-speechsauce/src/lib.rs
+++ b/py-speechsauce/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ::speechsauce::{config::SpeechConfig, feature, processing};
 use numpy::{
     IntoPyArray, PyArray1, PyArray2, PyArrayDyn, PyReadonlyArray1, PyReadonlyArray2,
@@ -141,6 +139,7 @@ impl IntoPy<SpeechConfig> for PySpeechSauce {
 // }
 
 #[pymodule]
+#[pyo3(name = "_internal")]
 fn speechsauce(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PySpeechSauce>()?;
     /// Compute MFCC features from an audio signal.
@@ -233,9 +232,9 @@ fn speechsauce(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         num_cepstral: usize,         // =13,
         num_filters: usize,          // =40,
         fft_length: usize,           // =512,
-        low_frequency: f32,          // =0,
-        high_frequency: Option<f32>, // =None,
+        low_frequency: f32,          // =0
         dc_elimination: bool,        //True
+        high_frequency: Option<f32>, // =None,
     ) -> Py<PySpeechSauce> {
         Py::new(
             py,

--- a/speechsauce/Cargo.toml
+++ b/speechsauce/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 ndarray="^0.15"
 ndrustfft = "0.4.0"
 num-traits = "0.2.15"
+num-complex = "0.4.3"
+itertools="0.10.5"
 #stft = {git="https://github.com/toastmod/stft.git",branch="master"}
 #apodise
 

--- a/speechsauce/Cargo.toml
+++ b/speechsauce/Cargo.toml
@@ -11,6 +11,8 @@ ndrustfft = "0.4.0"
 num-traits = "0.2.15"
 num-complex = "0.4.3"
 itertools="0.10.5"
+realfft = "3.2.0"
+einsum-derive = "0.1"
 #stft = {git="https://github.com/toastmod/stft.git",branch="master"}
 #apodise
 

--- a/speechsauce/Cargo.toml
+++ b/speechsauce/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ndarray="^0.15"
-ndrustfft = "^0.3"
+ndrustfft = "0.4.0"
 num-traits = "0.2.15"
 #stft = {git="https://github.com/toastmod/stft.git",branch="master"}
 #apodise

--- a/speechsauce/Cargo.toml
+++ b/speechsauce/Cargo.toml
@@ -14,6 +14,7 @@ itertools="0.10.5"
 realfft = "3.2.0"
 einsum-derive = "0.1"
 cached = "0.44.0"
+once_cell = "1.18.0"
 #stft = {git="https://github.com/toastmod/stft.git",branch="master"}
 #apodise
 

--- a/speechsauce/Cargo.toml
+++ b/speechsauce/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 ndarray="^0.15"
 ndrustfft = "^0.3"
 num-traits = "0.2.15"
+#stft = {git="https://github.com/toastmod/stft.git",branch="master"}
+#apodise
 
 [dev-dependencies]
 ndarray={version="^0.15",features=["approx"]}

--- a/speechsauce/Cargo.toml
+++ b/speechsauce/Cargo.toml
@@ -13,6 +13,7 @@ num-complex = "0.4.3"
 itertools="0.10.5"
 realfft = "3.2.0"
 einsum-derive = "0.1"
+cached = "0.44.0"
 #stft = {git="https://github.com/toastmod/stft.git",branch="master"}
 #apodise
 

--- a/speechsauce/src/config.rs
+++ b/speechsauce/src/config.rs
@@ -10,17 +10,17 @@ pub struct SpeechConfigBuilder {
     /// number of FFT points.
     fft_points: usize,
     /// the length of each frame in seconds.
-    frame_length: f64, // =0.020,
+    frame_length: f32, // =0.020,
     /// the step between successive frames in seconds.
-    frame_stride: f64, // =0.01,
+    frame_stride: f32, // =0.01,
     /// Number of cepstral coefficients.
     num_cepstral: usize, // =13,
     /// the number of filters in the filterbank
     num_filters: usize, // =40,
     ///lowest band edge of mel filters in Hz
-    low_frequency: f64,
+    low_frequency: f32,
     ///highest band edge of mel filters in Hz.
-    high_frequency: f64,
+    high_frequency: f32,
     /// If the first dc component should be eliminated or not
     dc_elimination: bool,
     // for mel_spectrogram
@@ -37,12 +37,12 @@ impl SpeechConfigBuilder {
             num_cepstral: 13,
             num_filters: 40,
             low_frequency: 0.0,
-            high_frequency: sample_rate as f64 / 2.0,
+            high_frequency: sample_rate as f32 / 2.0,
             dc_elimination: true,
         }
     }
 
-    pub fn high_freq(mut self, high_frequency: f64) -> SpeechConfigBuilder {
+    pub fn high_freq(mut self, high_frequency: f32) -> SpeechConfigBuilder {
         self.high_frequency = high_frequency;
         self
     }
@@ -52,7 +52,7 @@ impl SpeechConfigBuilder {
         self
     }
 
-    pub fn low_freq(mut self, low_frequency: f64) -> SpeechConfigBuilder {
+    pub fn low_freq(mut self, low_frequency: f32) -> SpeechConfigBuilder {
         self.low_frequency = low_frequency;
         self
     }
@@ -62,12 +62,12 @@ impl SpeechConfigBuilder {
         self
     }
 
-    pub fn frame_stride(mut self, frame_stride: f64) -> SpeechConfigBuilder {
+    pub fn frame_stride(mut self, frame_stride: f32) -> SpeechConfigBuilder {
         self.frame_stride = frame_stride;
         self
     }
 
-    pub fn frame_length(mut self, frame_length: f64) -> SpeechConfigBuilder {
+    pub fn frame_length(mut self, frame_length: f32) -> SpeechConfigBuilder {
         self.frame_length = frame_length;
         self
     }
@@ -99,36 +99,36 @@ pub struct SpeechConfig {
     /// number of FFT points.
     pub fft_points: usize,
     /// the length of each frame in seconds.
-    pub frame_length: f64, // =0.020,
+    pub frame_length: f32, // =0.020,
     /// the step between successive frames in seconds.
-    pub frame_stride: f64, // =0.01,
+    pub frame_stride: f32, // =0.01,
     /// Number of cepstral coefficients.
     pub num_cepstral: usize, // =13,
     /// the number of filters in the filterbank
     pub num_filters: usize, // =40,
     ///lowest band edge of mel filters in Hz
-    pub low_frequency: f64,
+    pub low_frequency: f32,
     ///highest band edge of mel filters in Hz.
-    pub high_frequency: f64,
+    pub high_frequency: f32,
     /// If the first dc component should be eliminated or not
     pub dc_elimination: bool,
     ///for
-    pub dct_handler: DctHandler<f64>,
-    pub fft_handler: R2cFftHandler<f64>,
+    pub dct_handler: DctHandler<f32>,
+    pub fft_handler: R2cFftHandler<f32>,
     /// Mel-filterbanks
-    pub filter_banks: Array2<f64>,
+    pub filter_banks: Array2<f32>,
 }
 
 impl SpeechConfig {
     pub fn new(
         sample_rate: usize,
         fft_points: usize,
-        frame_length: f64,
-        frame_stride: f64,
+        frame_length: f32,
+        frame_stride: f32,
         num_cepstral: usize,
         num_filters: usize,
-        low_frequency: f64,
-        high_frequency: f64,
+        low_frequency: f32,
+        high_frequency: f32,
         dc_elimination: bool,
     ) -> Self {
         Self {
@@ -146,7 +146,7 @@ impl SpeechConfig {
             filter_banks: filterbanks(
                 num_filters,
                 (fft_points / 2) + 1,
-                sample_rate as f64,
+                sample_rate as f32,
                 Some(low_frequency),
                 Some(high_frequency),
             ),

--- a/speechsauce/src/config.rs
+++ b/speechsauce/src/config.rs
@@ -127,8 +127,6 @@ pub struct SpeechConfig {
     pub dct_handler: DctHandler<f32>,
     pub fft_handler: R2cFftHandler<f32>,
     pub fft_forward: Arc<dyn RealToComplex<f32>>,
-    /// Mel-filterbanks
-    pub filter_banks: Array2<f32>,
     pub analysis_scratch: Vec<Complex32>,
 }
 
@@ -177,13 +175,6 @@ impl SpeechConfig {
             window,
             analysis_mem,
             analysis_scratch: analysis_scratch,
-            filter_banks: filterbanks(
-                num_filters,
-                (fft_points / 2) + 1,
-                sample_rate as f32,
-                Some(low_frequency),
-                Some(high_frequency),
-            ),
         }
     }
 

--- a/speechsauce/src/feature.rs
+++ b/speechsauce/src/feature.rs
@@ -176,7 +176,7 @@ pub fn mfe(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> (Array2<f32
     );
 
     // calculation of the power spectrum
-    let power_spectrum = crate::processing::power_spectrum(frames, speech_config.fft_points);
+    let power_spectrum = crate::processing::power_spectrum(frames, speech_config.window_size);
 
     // this stores the total energy in each frame
     let frame_energies = power_spectrum.sum_axis(Axis(1));

--- a/speechsauce/src/feature.rs
+++ b/speechsauce/src/feature.rs
@@ -133,8 +133,10 @@ pub fn mfcc(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> Array2<f64
     transformed_feature
 }
 //TODO: https://pytorch.org/audio/main/_modules/torchaudio/transforms/_transforms.html#MelSpectrogram
+//https://github.com/librosa/librosa/blob/c800e74f6a6ec5c27e0fa978d7355943cce04359/librosa/feature/spectral.py#LL2021C5-L2021C5
 fn mel_spectrogram(signal: ArrayView1<f64>, speech_config: &SpeechConfig) {
-    todo!()
+    //ndarray::einsum
+    todo!("implement mel_spectrogram")
 }
 ///a helper function that is passed to stack_frames from mfe
 fn _f_it(x: usize) -> Array2<f64> {

--- a/speechsauce/src/feature.rs
+++ b/speechsauce/src/feature.rs
@@ -89,10 +89,13 @@ pub(crate) fn filterbanks(
     filterbank
 }
 
+//TODO: refactor to use mel spectrogram
+//https://github.com/librosa/librosa/blob/519d6d97b0dc9bde42445513bcdfdb9b921d8b7f/librosa/feature/spectral.py#LL1832C8-L1832C8
 /// Compute MFCC features from an audio signal.
 ///     Args:
-///          signal : the audio signal from which to compute features.
+///          signal : the audio signal from which to compute features. Should be an 1-D array(currently)
 ///              Should be an N x 1 array
+///          
 pub fn mfcc(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> Array2<f32> {
     let (mut feature, energy) = mfe(signal, &speech_config);
 
@@ -145,7 +148,7 @@ pub fn mfcc(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> Array2<f32
 }
 //TODO: https://pytorch.org/audio/main/_modules/torchaudio/transforms/_transforms.html#MelSpectrogram
 //https://github.com/librosa/librosa/blob/c800e74f6a6ec5c27e0fa978d7355943cce04359/librosa/feature/spectral.py#LL2021C5-L2021C5
-pub fn mel_spectrogram1(signal: ArrayView1<f32>, speech_config: &mut SpeechConfig) -> Array2<f32> {
+pub fn mel_spectrogram1(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> Array2<f32> {
     let transformed_signal = stft1(signal, speech_config).mapv(|x| x.abs().powi(2));
     let filter_banks = filterbanks(
         speech_config.num_filters,
@@ -157,7 +160,7 @@ pub fn mel_spectrogram1(signal: ArrayView1<f32>, speech_config: &mut SpeechConfi
     //"...ft,mf->...mt"
     einsum!("ft,mf->mt", transformed_signal, filter_banks)
 }
-pub fn mel_spectrogram2(signal: ArrayView2<f32>, speech_config: &mut SpeechConfig) -> Array3<f32> {
+pub fn mel_spectrogram2(signal: ArrayView2<f32>, speech_config: &SpeechConfig) -> Array3<f32> {
     let transformed_signal = stft2(signal, speech_config).mapv(|x| x.abs().powi(2));
     let filter_banks = filterbanks(
         speech_config.num_filters,

--- a/speechsauce/src/feature.rs
+++ b/speechsauce/src/feature.rs
@@ -26,10 +26,10 @@ use ndrustfft::{nddct2, DctHandler};
 pub(crate) fn filterbanks(
     num_filter: usize,
     coefficients: usize,
-    sampling_freq: f64,
-    low_freq: Option<f64>,
-    high_freq: Option<f64>,
-) -> Array2<f64> {
+    sampling_freq: f32,
+    low_freq: Option<f32>,
+    high_freq: Option<f32>,
+) -> Array2<f32> {
     //TODO: compare to https://pytorch.org/audio/main/_modules/torchaudio/functional/functional.html#melscale_fbanks
     let high_freq = high_freq.unwrap_or(sampling_freq / 2.0);
     let low_freq = low_freq.unwrap_or(300.0);
@@ -43,7 +43,7 @@ pub(crate) fn filterbanks(
     // converting the upper and lower frequencies to Mels.
     // num_filter + 2 is because for num_filter filterbanks we need
     // num_filter+2 point.
-    let mels = Array1::<f64>::linspace(
+    let mels = Array1::<f32>::linspace(
         frequency_to_mel(low_freq),
         frequency_to_mel(high_freq),
         num_filter + 2,
@@ -56,7 +56,7 @@ pub(crate) fn filterbanks(
     // exact points calculated above should be extracted.
     //  So we should round those frequencies to the closest FFT bin.
     let freq_index = mel_arr_to_frequency(mels)
-        .map(|x| ((coefficients + 1) as f64 * x / sampling_freq) as usize);
+        .map(|x| ((coefficients + 1) as f32 * x / sampling_freq) as usize);
 
     // Initial definition
     let mut filterbank = Array2::zeros([num_filter, coefficients]);
@@ -67,12 +67,12 @@ pub(crate) fn filterbanks(
         let middle = freq_index[i + 1];
         let right = freq_index[i + 2];
 
-        let z = Array1::<f64>::linspace(left as f64, right as f64, right - left + 1);
+        let z = Array1::<f32>::linspace(left as f32, right as f32, right - left + 1);
 
         {
-            let mut s: ArrayViewMut1<f64> = filterbank.slice_mut(s![i, left..right + 1]);
+            let mut s: ArrayViewMut1<f32> = filterbank.slice_mut(s![i, left..right + 1]);
 
-            s.assign(&triangle(z, left as f64, middle as f64, right as f64));
+            s.assign(&triangle(z, left as f32, middle as f32, right as f32));
         }
     }
     filterbank
@@ -82,16 +82,16 @@ pub(crate) fn filterbanks(
 ///     Args:
 ///          signal : the audio signal from which to compute features.
 ///              Should be an N x 1 array
-pub fn mfcc(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> Array2<f64> {
+pub fn mfcc(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> Array2<f32> {
     let (mut feature, energy) = mfe(signal, &speech_config);
 
     if feature.is_empty() {
-        return Array::<f64, _>::zeros((0_usize, speech_config.num_cepstral));
+        return Array::<f32, _>::zeros((0_usize, speech_config.num_cepstral));
     }
     feature = feature.log();
     //feature second axis equal to num_filters
     let feature_axis_len = feature.shape()[1];
-    let mut transformed_feature = Array2::<f64>::zeros(feature.raw_dim());
+    let mut transformed_feature = Array2::<f32>::zeros(feature.raw_dim());
     //link to og code:
     //https://github.com/astorfi/speechpy/blob/2.4/speechpy/feature.py#L147
     //function dct docs:
@@ -103,13 +103,13 @@ pub fn mfcc(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> Array2<f64
     //4. norm="ortho": when used with dct type 2, applies a scaling factor
 
     //need to switch to rustfft, provide len of last axis specifically
-    let mut dct_handler: DctHandler<f64> = DctHandler::new(feature_axis_len);
+    let mut dct_handler: DctHandler<f32> = DctHandler::new(feature_axis_len);
 
     //need to check how to specify axis of transformation
     nddct2(&feature, &mut transformed_feature, &mut dct_handler, 1);
     //NOTE: may be able to remove the if/else by processing first element separately
     //https://docs.scipy.org/doc/scipy/reference/generated/scipy.fftpack.dct.html#:~:text=2N)-,If%20norm%3D%27ortho%27%2C%20y%5Bk%5D%20is%20multiplied%20by%20a%20scaling%20factor%20f,-f%3D%7B
-    let n = transformed_feature.len() as f64;
+    let n = transformed_feature.len() as f32;
     //orthonormalized the transformed axis
     transformed_feature[[0, 0]] *= 1. / (4. * n).sqrt();
     transformed_feature
@@ -133,12 +133,12 @@ pub fn mfcc(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> Array2<f64
     transformed_feature
 }
 //TODO: https://pytorch.org/audio/main/_modules/torchaudio/transforms/_transforms.html#MelSpectrogram
-fn mel_spectrogram(signal: ArrayView1<f64>, speech_config: &SpeechConfig) {
+fn mel_spectrogram(signal: ArrayView1<f32>, speech_config: &SpeechConfig) {
     todo!()
 }
 ///a helper function that is passed to stack_frames from mfe
-fn _f_it(x: usize) -> Array2<f64> {
-    Array2::<f64>::ones((x, 1))
+fn _f_it(x: usize) -> Array2<f32> {
+    Array2::<f32>::ones((x, 1))
 }
 
 /// Compute Mel-filterbank energy features from an audio signal.
@@ -161,7 +161,7 @@ fn _f_it(x: usize) -> Array2<f64> {
 ///    Returns:
 ///         array: features - the energy of fiterbank of size num_frames x num_filters.
 ///         The energy of each frame: num_frames x 1
-pub fn mfe(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> (Array2<f64>, Array1<f64>) {
+pub fn mfe(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> (Array2<f32>, Array1<f32>) {
     //
     // Stack frames
     let frames = stack_frames(
@@ -196,7 +196,7 @@ pub fn mfe(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> (Array2<f64
 ///         speech_config: the configuration for the speech processing functions
 ///    Returns:
 ///         array: Features - The log energy of fiterbank of size num_frames x num_filters frame_log_energies. The log energy of each frame num_frames x 1
-fn lmfe(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> Array2<f64> {
+fn lmfe(signal: ArrayView1<f32>, speech_config: &SpeechConfig) -> Array2<f32> {
     let (feature, _) = mfe(signal, speech_config);
     feature.log()
 }
@@ -207,7 +207,7 @@ fn lmfe(signal: ArrayView1<f64>, speech_config: &SpeechConfig) -> Array2<f64> {
 ///     feature : The feature vector which its size is: N x M
 /// Return:
 ///     array: The feature cube vector which contains the static, first and second derivative features of size: N x M x 3
-fn extract_derivative_feature(feature: Array2<f64>) -> Array3<f64> {
+fn extract_derivative_feature(feature: Array2<f32>) -> Array3<f32> {
     let first_derivative_feature = crate::processing::derivative_extraction(&feature, 2);
     let second_derivative_feature =
         crate::processing::derivative_extraction(&first_derivative_feature, 2);

--- a/speechsauce/src/functions.rs
+++ b/speechsauce/src/functions.rs
@@ -1,32 +1,34 @@
 /// contains necessary functions for calculating the features in the `features` module.
 use ndarray::{Array, Array1, Dimension, Zip};
 
-
 /// converts a single value representing a frequency in Hz to Mel scale.
-pub fn frequency_to_mel(f: f64) -> f64 {
+pub fn frequency_to_mel(f: f32) -> f32 {
     1127. * (1. + f / 700.).ln()
 }
 ///converts all values in the input array from frequency to mel scale
-pub fn frequency_arr_to_mel<D>(freq: Array<f64,D>) -> Array<f64,D> 
-where D: Dimension{
+pub fn frequency_arr_to_mel<D>(freq: Array<f32, D>) -> Array<f32, D>
+where
+    D: Dimension,
+{
     freq.mapv(|v| 1127. * (1. + v / 700.).ln())
 }
 
 /// converts a single value from the mel scale to a frequency scale.
-pub fn mel_to_frequency<D>(mel: f64)-> f64 {
+pub fn mel_to_frequency<D>(mel: f32) -> f32 {
     700. * ((mel / 1127.0).exp() - 1.)
 }
 
 ///converts all values in the input array from mel scale to frequency scale
-pub fn mel_arr_to_frequency<D>(mel: Array<f64,D>) -> Array<f64,D> 
-where D: Dimension{
+pub fn mel_arr_to_frequency<D>(mel: Array<f32, D>) -> Array<f32, D>
+where
+    D: Dimension,
+{
     mel.mapv(|v| 700. * ((v / 1127.0).exp() - 1.))
 }
 
-
-pub fn triangle( arr: Array1<f64>, left: f64, middle: f64, right: f64) -> Array1<f64> {
+pub fn triangle(arr: Array1<f32>, left: f32, middle: f32, right: f32) -> Array1<f32> {
     //original function: https://github.com/astorfi/speechpy/blob/master/speechpy/functions.py#L44
-    let mut out=ndarray::Array1::<f64>::zeros(arr.len());
+    let mut out = ndarray::Array1::<f32>::zeros(arr.len());
     Zip::from(&mut out).and(&arr).for_each(|v, x| {
         if (left..right).contains(x) {
             //TODO: fix range bounds to be exclusive, see https://github.com/rust-lang/rust/issues/37854
@@ -47,9 +49,9 @@ pub fn triangle( arr: Array1<f64>, left: f64, middle: f64, right: f64) -> Array1
 ///    to become an argument for any log function.
 ///    :param x: The vector.
 ///    :return: The vector with zeros substituted with epsilon values.
-pub fn zero_handling<D>(x: Array<f64, D>) -> Array<f64, D>
+pub fn zero_handling<D>(x: Array<f32, D>) -> Array<f32, D>
 where
     D: Dimension,
 {
-    x.mapv(|x| if x == 0.0 { std::f64::EPSILON } else { x })
+    x.mapv(|x| if x == 0.0 { std::f32::EPSILON } else { x })
 }

--- a/speechsauce/src/functions.rs
+++ b/speechsauce/src/functions.rs
@@ -1,32 +1,37 @@
 /// contains necessary functions for calculating the features in the `features` module.
-use ndarray::{Array, Array1, Dimension, Zip};
+use ndarray::{s, Array, Array1, ArrayD, Dimension, Zip};
+use stft::realfft::RealFftPlanner;
 
+use crate::util::PadType;
 
 /// converts a single value representing a frequency in Hz to Mel scale.
 pub fn frequency_to_mel(f: f64) -> f64 {
     1127. * (1. + f / 700.).ln()
 }
 ///converts all values in the input array from frequency to mel scale
-pub fn frequency_arr_to_mel<D>(freq: Array<f64,D>) -> Array<f64,D> 
-where D: Dimension{
+pub fn frequency_arr_to_mel<D>(freq: Array<f64, D>) -> Array<f64, D>
+where
+    D: Dimension,
+{
     freq.mapv(|v| 1127. * (1. + v / 700.).ln())
 }
 
 /// converts a single value from the mel scale to a frequency scale.
-pub fn mel_to_frequency<D>(mel: f64)-> f64 {
+pub fn mel_to_frequency<D>(mel: f64) -> f64 {
     700. * ((mel / 1127.0).exp() - 1.)
 }
 
 ///converts all values in the input array from mel scale to frequency scale
-pub fn mel_arr_to_frequency<D>(mel: Array<f64,D>) -> Array<f64,D> 
-where D: Dimension{
+pub fn mel_arr_to_frequency<D>(mel: Array<f64, D>) -> Array<f64, D>
+where
+    D: Dimension,
+{
     mel.mapv(|v| 700. * ((v / 1127.0).exp() - 1.))
 }
 
-
-pub fn triangle( arr: Array1<f64>, left: f64, middle: f64, right: f64) -> Array1<f64> {
+pub fn triangle(arr: Array1<f64>, left: f64, middle: f64, right: f64) -> Array1<f64> {
     //original function: https://github.com/astorfi/speechpy/blob/master/speechpy/functions.py#L44
-    let mut out=ndarray::Array1::<f64>::zeros(arr.len());
+    let mut out = ndarray::Array1::<f64>::zeros(arr.len());
     Zip::from(&mut out).and(&arr).for_each(|v, x| {
         if (left..right).contains(x) {
             //TODO: fix range bounds to be exclusive, see https://github.com/rust-lang/rust/issues/37854
@@ -52,4 +57,82 @@ where
     D: Dimension,
 {
     x.mapv(|x| if x == 0.0 { std::f64::EPSILON } else { x })
+}
+
+// https://github.com/librosa/librosa/blob/c800e74f6a6ec5c27e0fa978d7355943cce04359/librosa/core/spectrum.py#L46
+///Short time Fourier transform (STFT)
+/// TODO:
+fn stft(
+    y: &ArrayD<f64>,
+    n_fft: usize,
+    hop_length: Option<usize>,
+    win_length: Option<usize>,
+    window: &ArrayD<f64>,
+    center: bool,
+    pad_mode: PadType,
+) -> ArrayD<f64> {
+    // By default, use the entire frame
+    let win_length = win_length.unwrap_or(n_fft);
+
+    // Set the default hop, if it's not already specified
+    let hop_length = match hop_length {
+        Some(hop) if hop > 0 => hop,
+        Some(hop) => panic!("hop_length={} must be a positive integer", hop),
+        None => win_length / 4,
+    };
+
+    // Check audio is valid
+    assert!(
+        y.ndim() >= 1 && y.ndim() <= 2,
+        "y must have 1 or 2 dimensions"
+    );
+
+    // Compute the window
+    let fft_window = compute_fft_window(window, win_length, n_fft);
+
+    // Compute the padding
+    let (padded_y, start, extra) = compute_padding(y, center, pad_mode, n_fft, hop_length);
+
+    // Allocate the STFT matrix
+    let n_frames = (y.len() - start) / hop_length + 1 + extra;
+    let stft_matrix = if let Some(mut out_array) = out {
+        assert!(
+            out_array.shape()[..out_array.ndim() - 1]
+                == &[1 + n_fft / 2, n_frames.try_into().unwrap()],
+            "Shape mismatch for provided output array"
+        );
+        out_array.view_mut()
+    } else {
+        Array::zeros((1 + n_fft / 2, n_frames.try_into().unwrap()))
+    };
+
+    // Compute the STFT
+    let mut planner = RealFftPlanner::new();
+    let fft = planner.plan_fft_forward(n_fft);
+    let mut input_frame = Array::zeros((n_fft,));
+    for t in 0..n_frames {
+        let t_offset = start + t * hop_length;
+        input_frame.assign(&padded_y.slice(s![t_offset..t_offset + n_fft]));
+        input_frame *= &fft_window;
+        let fft_output = ndfft_r compute_fft(&mut fft, &input_frame);
+        let stft_frame = &mut stft_matrix.slice_mut(s![.., t]);
+        copy_stft_frame(fft_output, stft_frame);
+    }
+
+    stft_matrix
+}
+
+fn compute_fft_window(window: &NdArrayD, win_length: usize, n_fft: usize) -> ArrayD<f32> {
+    let fft_window = if window.shape() == &[win_length] {
+        window.view()
+    } else {
+        let fft_window = window
+            .into_shape((win_length,))
+            .unwrap_or_else(|_| {
+                panic!("window must have length equal to or less than win_length={}", win_length)
+            })
+            .to_owned();
+        pad_fft_window(&fft_window, n_fft)
+    };
+    fft_window.to_owned()
 }

--- a/speechsauce/src/lib.rs
+++ b/speechsauce/src/lib.rs
@@ -15,7 +15,7 @@ mod tests {
 
     use crate::processing::{cmvn, preemphasis, stack_frames};
 
-    fn create_signal() -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 1]>> {
+    fn create_signal() -> ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<[usize; 1]>> {
         let mu = 0.; //mean
         let sigma = 0.1; //standard deviation
         Array::random(1000000, Normal::new(mu, sigma).unwrap())
@@ -31,12 +31,12 @@ mod tests {
     fn get_num_frames(
         signal_len: usize,
         sample_rate: usize,
-        frame_length: f64,
-        frame_stride: f64,
+        frame_length: f32,
+        frame_stride: f32,
     ) -> usize {
-        let window_size = (frame_length * sample_rate as f64).round();
-        let step = (frame_stride * sample_rate as f64).round();
-        ((signal_len as f64 - window_size) / step).ceil() as usize
+        let window_size = (frame_length * sample_rate as f32).round();
+        let step = (frame_stride * sample_rate as f32).round();
+        ((signal_len as f32 - window_size) / step).ceil() as usize
     }
     #[test]
     fn test_preemphasis() {
@@ -53,7 +53,7 @@ mod tests {
         let freq = sampling_frequency();
         let frame_length = 0.02;
         let frame_stride = 0.02;
-        //let filter: fn(usize) -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 1]>> = |x:usize| -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 1]>> {Array1::<f64>::ones(x)};
+        //let filter: fn(usize) -> ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<[usize; 1]>> = |x:usize| -> ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<[usize; 1]>> {Array1::<f32>::ones(x)};
         let zero_padding = true;
         let frames = stack_frames(
             signal.view(),
@@ -80,6 +80,10 @@ mod tests {
         let output_mean = normalized_feature.mean_axis(ndarray::Axis(0)).unwrap();
         //TODO: verify the shape of cvmn and np.zeroes((1,x))
         //should be comparing two 1d arrays in original code
+        // println!(
+        //     "{:?}",
+        //     (&output_mean - &ndarray::Array1::<f32>::zeros(normalized_feature.shape()[1]))
+        // );
         assert!(
             output_mean.abs_diff_eq(&ndarray::Array1::zeros(normalized_feature.shape()[1]), 1e-8)
         );

--- a/speechsauce/src/util.rs
+++ b/speechsauce/src/util.rs
@@ -416,8 +416,9 @@ mod test {
     fn pad_center1_test() {
         let input_arr = array![[1, 2, 3, 4]];
         let size = 9;
-        let padded_arr = pad_center1(input_arr.view(), size, PadType::Constant(0));
-        assert_eq!(padded_arr, array![[0, 0, 1, 2, 3, 4, 0, 0, 0]])
+        // let padded_arr = pad_center1(input_arr.view(), size, PadType::Constant(0));
+        // assert_eq!(padded_arr, array![[0, 0, 1, 2, 3, 4, 0, 0, 0]])
+        todo!()
     }
 
     //TODO: add test for pad

--- a/speechsauce/src/util.rs
+++ b/speechsauce/src/util.rs
@@ -1,12 +1,4 @@
-
-
-use ndarray::{
-    Array, Array2, ArrayView, ArrayViewMut, Axis,
-    Dimension, Slice, ArrayView2, s,
-};
-
-
-
+use ndarray::{s, Array, Array2, ArrayView, ArrayView2, ArrayViewMut, Axis, Dimension, Slice};
 
 pub(crate) enum PadType {
     Constant,
@@ -22,18 +14,15 @@ pub(crate) enum EdgeColOp {
     Right,
 }
 
-
 //this works for how repeat is called in our project
-pub(crate) fn repeat_axis<A>(arr: ArrayView2<A>, ax:Axis, nrep: usize) -> Array2<A>
+pub(crate) fn repeat_axis<A>(arr: ArrayView2<A>, ax: Axis, nrep: usize) -> Array2<A>
 where
     A: Clone + std::fmt::Display + num_traits::Zero,
-    
 {
-       
-    ndarray::concatenate(ax, &vec![arr;nrep]).unwrap()
+    ndarray::concatenate(ax, &vec![arr; nrep]).unwrap()
 }
 
-//prepends 
+//prepends
 fn _new_shape(current_ndims: usize, min_ndims: usize, reps: &mut Vec<usize>) {
     if current_ndims < min_ndims {
         // in case of fire: https://github.com/numpy/numpy/blob/v1.22.0/numpy/lib/shape_base.py#L1250
@@ -59,12 +48,11 @@ fn _new_shape(current_ndims: usize, min_ndims: usize, reps: &mut Vec<usize>) {
 /// potentially relevant SO post: https://stackoverflow.com/questions/61758934/how-can-i-write-a-generic-function-that-takes-either-an-ndarray-array-or-arrayvi
 
 pub(crate) fn pad(
-    arr: &Array2<f64>,
+    arr: &Array2<f32>,
     pad_width: Vec<[usize; 2]>,
-    const_value: f64,
+    const_value: f32,
     pad_type: PadType,
-) -> Array2<f64>
-{
+) -> Array2<f32> {
     assert_eq!(
         arr.ndim(),
         pad_width.len(),
@@ -82,9 +70,9 @@ pub(crate) fn pad(
     {
         // Select portion of padded array that needs to be copied from the
         // original array.
-        let row=arr.shape()[0];
-        let col=arr.shape()[1];
-        let mut orig_portion = padded.slice_mut(s![..row,..col]);
+        let row = arr.shape()[0];
+        let col = arr.shape()[1];
+        let mut orig_portion = padded.slice_mut(s![..row, ..col]);
         // Copy the data from the original array.
         orig_portion.assign(arr);
         match pad_type {
@@ -369,28 +357,34 @@ impl<A: num_traits::real::Real, I: ndarray::Dimension> ArrayLog<A, I> for Array<
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use ndarray::array;
     use ndarray::concatenate;
-    use super::*;
-
-    
 
     #[test]
-    fn tile_equiv_test(){
-        let arr1= array![[1,2],[3,4]];
-        let arr2=array![[1,2,3,4]];
+    fn tile_equiv_test() {
+        let arr1 = array![[1, 2], [3, 4]];
+        let arr2 = array![[1, 2, 3, 4]];
         //these two assertions are from the examples in the numpy docs for tiling with reps all one save
         //for first value
         //https://numpy.org/doc/stable/reference/generated/numpy.tile.html
-        assert_eq!(concatenate![Axis(0),arr1,arr1], array![[1,2],[3,4],[1,2],[3,4]]);
-        assert_eq!(repeat_axis(arr2.view(),Axis(0),4),array![[1,2,3,4],[1,2,3,4],[1,2,3,4],[1,2,3,4]])
-
+        assert_eq!(
+            concatenate![Axis(0), arr1, arr1],
+            array![[1, 2], [3, 4], [1, 2], [3, 4]]
+        );
+        assert_eq!(
+            repeat_axis(arr2.view(), Axis(0), 4),
+            array![[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
+        )
     }
 
     #[test]
     fn repeat_test() {
-        let input_arr=array![[1,2,3,4]];
-        assert_eq!(repeat_axis(input_arr.view(),Axis(0),2),array![[1,2,3,4],[1,2,3,4]])
+        let input_arr = array![[1, 2, 3, 4]];
+        assert_eq!(
+            repeat_axis(input_arr.view(), Axis(0), 2),
+            array![[1, 2, 3, 4], [1, 2, 3, 4]]
+        )
     }
 
     //TODO: add test for pad


### PR DESCRIPTION
this branch currently compiles and hasn't modified any existing functions yet(other than moving from f64 to f32), so there isn't any reason to not merge it. Test still need to be written for mel_spectrogram 1&2, and we may want to migrate mfcc to use the mel_spectrogram function, similar to librosa's library. 

also, we *might* want to extract the stft stuff into it's own crate, partially because I copied that from another rust project by rikorose, and it's probably useful for other people doing stuff related to audio processing (not necessarily limited to speech processing). 